### PR TITLE
Add quickstart installer package

### DIFF
--- a/kubebench/kubebench-quickstarter/kubebench-quickstarter-service.libsonnet
+++ b/kubebench/kubebench-quickstarter/kubebench-quickstarter-service.libsonnet
@@ -1,0 +1,184 @@
+local k = import "k.libsonnet";
+
+{
+  parts:: {
+    nfsDeployment(name, namespace):: {
+      apiVersion: "extensions/v1beta1",
+      kind: "Deployment",
+      metadata: {
+        name: name,
+        namespace: namespace,
+        labels: {
+          role: "kubebench-nfs",
+        },
+      },
+      spec: {
+        template: {
+          metadata: {
+            labels: {
+              role: "kubebench-nfs",
+            },
+          },
+          spec: {
+            volumes: [
+              {
+                name: "git-repo",
+                emptyDir: {},
+              },
+              {
+                name: "kubebench",
+                emptyDir: {},
+              },
+            ],
+            initContainers: [
+              {
+                name: "init-clone-repo",
+                image: "alpine/git",
+                args: [
+                  "clone",
+                  "--single-branch",
+                  "--",
+                  "https://github.com/kubeflow/kubebench.git",
+                  "/kubebench/repo",
+                ],
+                volumeMounts: [
+                  {
+                    name: "git-repo",
+                    mountPath: "/kubebench/repo",
+                  },
+                ],
+              },
+              {
+                name: "copy-data",
+                image: "busybox",
+                command: [
+                  "sh",
+                ],
+                args: [
+                  "-c",
+                  "mkdir -p /mnt/kubebench/config/registry ; " +
+                  "mkdir -p /mnt/kubebench/data ; " +
+                  "mkdir -p /mnt/kubebench/experiments ; " +
+                  "cp -r /kubebench-repo/kubebench /mnt/kubebench/config/registry/ ; " +
+                  "cp -r /kubebench-repo/examples/config/* /mnt/kubebench/config",
+                ],
+                volumeMounts: [
+                  {
+                    name: "git-repo",
+                    mountPath: "/kubebench-repo",
+                  },
+                  {
+                    name: "kubebench",
+                    mountPath: "/mnt",
+                  },
+                ],
+              },
+            ],
+            containers: [
+              {
+                name: "kubebench-nfs-server",
+                image: "k8s.gcr.io/volume-nfs:0.8",
+                volumeMounts: [
+                  {
+                    name: "kubebench",
+                    mountPath: "/exports",
+                  },
+                ],
+                ports: [
+                  {
+                    name: "nfs",
+                    containerPort: 2049,
+                  },
+                  {
+                    name: "mountd",
+                    containerPort: 20048,
+                  },
+                  {
+                    name: "rpcbind",
+                    containerPort: 111,
+                  },
+                ],
+                securityContext: {
+                  privileged: true,
+                },
+              },
+              {
+                name: "kubebench-nfs-file-server",
+                image: "python:alpine3.7",
+                command: [
+                  "sh",
+                ],
+                args: [
+                  "-c",
+                  "cd /mnt/kubebench ; python3 -m http.server",
+                ],
+                volumeMounts: [
+                  {
+                    name: "kubebench",
+                    mountPath: "/mnt",
+                  },
+                ],
+                ports: [
+                  {
+                    name: "file-server",
+                    containerPort: 8000,
+                  },
+                ],
+              },
+            ],  // containers
+          },
+        },  // template
+      },
+    },  // nfsDeployment
+
+    nfsService(name, namespace, serviceType):: {
+      kind: "Service",
+      apiVersion: "v1",
+      metadata: {
+        name: name,
+        namespace: namespace,
+      },
+      spec: {
+        type: serviceType,
+        ports: [
+          {
+            name: "nfs",
+            port: 2049,
+          },
+          {
+            name: "mountd",
+            port: 20048,
+          },
+          {
+            name: "rpcbind",
+            port: 111,
+          },
+        ],
+        selector: {
+          role: "kubebench-nfs",
+        },
+      },
+    },  // nfsService
+
+    nfsFileServerService(name, namespace, serviceType):: {
+      kind: "Service",
+      apiVersion: "v1",
+      metadata: {
+        name: name,
+        namespace: namespace,
+      },
+      spec: {
+        type: serviceType,
+        ports: [
+          {
+            name: "file-server",
+            port: 8000,
+          },
+        ],
+        selector: {
+          role: "kubebench-nfs",
+        },
+      },
+    },  // nfsFileServerService
+  },
+}

--- a/kubebench/kubebench-quickstarter/kubebench-quickstarter-volume.libsonnet
+++ b/kubebench/kubebench-quickstarter/kubebench-quickstarter-volume.libsonnet
@@ -1,0 +1,50 @@
+local k = import "k.libsonnet";
+
+{
+  parts:: {
+    nfsPV(name, namespace, serverip, capacity, path, label):: {
+      apiVersion: "v1",
+      kind: "PersistentVolume",
+      metadata: {
+        name: name,
+        namespace: namespace,
+        labels: {
+          kubebenchVolumeType: label,
+        },
+      },
+      spec: {
+        capacity: {
+          storage: capacity,
+        },
+        accessModes: ["ReadWriteMany"],
+        nfs: {
+          server: serverip,
+          path: path,
+        },
+      },
+    },
+
+    nfsPVC(name, namespace, storage_request, label):: {
+      apiVersion: "v1",
+      kind: "PersistentVolumeClaim",
+      metadata: {
+        name: name,
+        namespace: namespace,
+      },
+      spec: {
+        accessModes: ["ReadWriteMany"],
+        storageClassName: "",
+        resources: {
+          requests: {
+            storage: storage_request,
+          },
+        },
+        selector: {
+          matchLabels: {
+            kubebenchVolumeType: label,
+          },
+        },
+      },
+    },
+  },
+}

--- a/kubebench/kubebench-quickstarter/parts.yaml
+++ b/kubebench/kubebench-quickstarter/parts.yaml
@@ -1,0 +1,34 @@
+{
+   "name": "kubebench-quickstarter",
+   "apiVersion": "0.0.1",
+   "kind": "ksonnet.io/parts",
+   "description": "Quick-start installer for Kubebench\n",
+   "author": "Cisco Systems, Inc.",
+   "contributors": [
+      {
+         "name": "Xinyuan Huang",
+         "email": "xinyuahu@cisco.com"
+      }
+   ],
+   "repository": {
+      "type": "git",
+      "url": "https://github.com/kubeflow/kubebench"
+   },
+   "bugs": {
+      "url": "https://github.com/kubeflow/kubebench/issues"
+   },
+   "keywords": [
+      "kubeflow",
+      "benchmark"
+   ],
+   "quickStart": {
+      "prototype": "io.ksonnet.pkg.kubebench-quickstarter",
+      "componentName": "kubebench-quickstarter",
+      "flags": {
+         "name": "kubebench-quickstarter",
+         "namespace": "default"
+      },
+      "comment": "Run Kubebench quick-start installer"
+   },
+   "license": "Apache 2.0"
+}

--- a/kubebench/kubebench-quickstarter/prototypes/kubebench-quickstarter-service.jsonnet
+++ b/kubebench/kubebench-quickstarter/prototypes/kubebench-quickstarter-service.jsonnet
@@ -1,0 +1,23 @@
+// @apiVersion 0.1
+// @name io.ksonnet.pkg.kubebench-quickstarter-service
+// @description Kubebench quick-start service installer
+// @shortDescription Kubebench quick-start service installer
+// @param name string Name for the installer.
+// @optionalParam namespace string null Namespace to use for the components
+// @optionalParam nfsServiceType string ClusterIP Service type of the nfs service
+// @optionalParam nfsFileServerServiceType string ClusterIP Service type of the nfs file server
+
+local k = import "k.libsonnet";
+local nfsSvc = import "kubebench/kubebench-quickstarter/kubebench-quickstarter-service.libsonnet";
+
+local name = import "param://name";
+local namespace = if params.namespace == "null" then env.namespace else params.namespace;
+
+local nfsServiceType = params.nfsServiceType;
+local nfsFileServerServiceType = params.nfsFileServerServiceType;
+
+std.prune(k.core.v1.list.new([
+  nfsSvc.parts.nfsDeployment("kubebench-nfs-deploy", namespace),
+  nfsSvc.parts.nfsService("kubebench-nfs-svc", namespace, nfsServiceType),
+  nfsSvc.parts.nfsFileServerService("kubebench-nfs-file-server-svc", namespace, nfsFileServerServiceType),
+]))

--- a/kubebench/kubebench-quickstarter/prototypes/kubebench-quickstarter-volume.jsonnet
+++ b/kubebench/kubebench-quickstarter/prototypes/kubebench-quickstarter-volume.jsonnet
@@ -1,0 +1,26 @@
+// @apiVersion 0.1
+// @name io.ksonnet.pkg.kubebench-quickstarter-volume
+// @description Kubebench quick-start volume installer
+// @shortDescription Kubebench quick-start volume installer
+// @param name string Name for the installer.
+// @optionalParam namespace string null Namespace to use for the components
+// @optionalParam nfsServiceIP string null service type of the nfs file server
+
+local k = import "k.libsonnet";
+local nfsVol = import "kubebench/kubebench-quickstarter/kubebench-quickstarter-volume.libsonnet";
+
+local name = import "param://name";
+local namespace = if params.namespace == "null" then env.namespace else params.namespace;
+local nfsServiceIP = params.nfsServiceIP;
+
+local capacity = "1Gi";
+local storageRequest = "1Gi";
+
+std.prune(k.core.v1.list.new([
+  nfsVol.parts.nfsPV("kubebench-config-pv", namespace, nfsServiceIP, capacity, "/kubebench/config", "config"),
+  nfsVol.parts.nfsPVC("kubebench-config-pvc", namespace, storageRequest, "config"),
+  nfsVol.parts.nfsPV("kubebench-data-pv", namespace, nfsServiceIP, capacity, "/kubebench/data", "data"),
+  nfsVol.parts.nfsPVC("kubebench-data-pvc", namespace, storageRequest, "data"),
+  nfsVol.parts.nfsPV("kubebench-exp-pv", namespace, nfsServiceIP, capacity, "/kubebench/experiments", "experiments"),
+  nfsVol.parts.nfsPVC("kubebench-exp-pvc", namespace, storageRequest, "experiments"),
+]))

--- a/kubebench/registry.yaml
+++ b/kubebench/registry.yaml
@@ -7,6 +7,9 @@ libraries:
   kubebench-job:
     version: master
     path: kubebench-job
+  kubebench-quickstarter:
+    version: master
+    path: kubebench-quickstarter
   nfs-server:
     version: master
     path: nfs-server


### PR DESCRIPTION
The installer provides a nfs service and corresponding volumes, along with a simple file server to help user view the nfs contents before & after benchmarks.

Fix #73

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubebench/79)
<!-- Reviewable:end -->
