### PR TITLE
Set name for wait_for_deployment test suite in e2e tests

### DIFF
--- a/test/py/kubebench/test/wait_for_deployment.py
+++ b/test/py/kubebench/test/wait_for_deployment.py
@@ -81,7 +81,7 @@ def test_wait_for_deployment(test_case): # pylint: disable=redefined-outer-name,
 
 if __name__ == "__main__":
   test_case = test_helper.TestCase(
-    name="test_wait_for_deployment", test_func=test_wait_for_deployment)
+    name="wait_for_deployment", test_func=test_wait_for_deployment)
   test_suite = test_helper.init(
-    name="", test_cases=[test_case])
+    name="test_wait_for_deployment", test_cases=[test_case])
   test_suite.run()


### PR DESCRIPTION
Fixes e2e testing error.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubebench/82)
<!-- Reviewable:end -->
