### PR TITLE
Controller functionality updates

### DIFF
--- a/controller/cmd/configurator/app/options.go
+++ b/controller/cmd/configurator/app/options.go
@@ -19,8 +19,9 @@ import (
 )
 
 type AppOption struct {
-	ConfigFile string
-	OutputFile string
+	Config             string
+	ManifestOutput     string
+	ExperimentIDOutput string
 }
 
 func NewAppOption() *AppOption {
@@ -29,6 +30,9 @@ func NewAppOption() *AppOption {
 }
 
 func (opt *AppOption) AddFlags(fs *flag.FlagSet) {
-	fs.StringVar(&opt.ConfigFile, "config-file", "", "The configuration file.")
-	fs.StringVar(&opt.OutputFile, "output-file", "", "The output file.")
+	fs.StringVar(&opt.Config, "config", "", "The configuration file.")
+	fs.StringVar(&opt.ManifestOutput, "manifest-output", "kf-job-manifest.yaml",
+		"The output manifest file.")
+	fs.StringVar(&opt.ExperimentIDOutput, "experiment-id-output", "experiment-id",
+		"The output experiment id file.")
 }

--- a/controller/cmd/configurator/main.go
+++ b/controller/cmd/configurator/main.go
@@ -24,15 +24,16 @@ import (
 )
 
 func run(opt *app.AppOption) error {
-	configFile := opt.ConfigFile
-	outputFile := opt.OutputFile
+	config := opt.Config
+	manifestOutput := opt.ManifestOutput
+	experimentIDOutput := opt.ExperimentIDOutput
 
 	configurator := app.Configurator{
 		FileOperator:      &(app.FileOperator{}),
 		ManifestGenerator: &(app.ManifestGenerator{}),
 	}
 
-	if err := configurator.Run(configFile, outputFile); err != nil {
+	if err := configurator.Run(config, manifestOutput, experimentIDOutput); err != nil {
 		log.Errorf("Configurator failed to run: %s", err)
 		return err
 	}

--- a/controller/cmd/reporter/app/csv_reporter.go
+++ b/controller/cmd/reporter/app/csv_reporter.go
@@ -65,7 +65,9 @@ func (cr *CsvReporter) Run(options ReporterOption) error {
 }
 
 func (cr *CsvReporter) readInput(filePath string) (map[string]interface{}, error) {
-	data, err := ioutil.ReadFile(filePath)
+	// the experiment result's path is relative to $KUBEBENCH_EXP_RESULT_PATH
+	expResultDir := os.Getenv("KUBEBENCH_EXP_RESULT_PATH")
+	data, err := ioutil.ReadFile(path.Join(expResultDir, filePath))
 	if err != nil {
 		log.Errorf("Could not read file: %s. Error: %s", filePath, err)
 		return nil, err
@@ -80,13 +82,15 @@ func (cr *CsvReporter) readInput(filePath string) (map[string]interface{}, error
 }
 
 func (cr *CsvReporter) appendResult(filePath string, input map[string]interface{}) error {
-	dir, _ := path.Split(filePath)
+	// the report's path is relative to $KUBEBENCH_EXP_ROOT
+	expRootDir := os.Getenv("KUBEBENCH_EXP_ROOT")
+	dir, _ := path.Split(path.Join(expRootDir, filePath))
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		log.Errorf("Failed to create directory: %s", err)
 		return err
 	}
 
-	f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0644)
+	f, err := os.OpenFile(path.Join(expRootDir, filePath), os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This patch includes following updates to the controller functionalities:

- Configurator to generate experiment-id output along with job manifest
- Configurator automatically initializes experiment directory
- Configurator retrieves job configs through env-defined relative path
- Reporter reads/writes result/report through env-defined relative paths

Fix #80, Fix #85, Fix #86.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubebench/83)
<!-- Reviewable:end -->
