### PR TITLE
Fix example tf-cnn job prototype for worker only job

### DIFF
--- a/kubebench/kubebench-examples/prototypes/tf-cnn.jsonnet
+++ b/kubebench/kubebench-examples/prototypes/tf-cnn.jsonnet
@@ -77,6 +77,7 @@ local tfjob = {
           },
         },
       },
+    } + if numPs > 0 then {
       Ps: {
         replicas: numPs,
         template: {
@@ -104,7 +105,7 @@ local tfjob = {
         },
         tfReplicaType: "PS",
       },
-    },
+    } else {},
   },
 };
 


### PR DESCRIPTION
This fixes the ksonnet prototype of tf-cnn example job to support situations where only workers and no ps is requested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubebench/100)
<!-- Reviewable:end -->
