### PR TITLE
Add resource-manager for managing resource actions inside workflows

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -484,11 +484,12 @@
   version = "kubernetes-1.12.0"
 
 [[projects]]
-  digest = "1:e37fe587e215f7e706a5898c76d6b74d7c518fca917b6681c36608a4e2ce888e"
+  digest = "1:bc1b24794fababade27071268c8fe27b5dd0e4be16e1eed99e96ae7458445fb3"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
     "discovery/fake",
+    "dynamic",
     "kubernetes",
     "kubernetes/scheme",
     "kubernetes/typed/admissionregistration/v1alpha1",
@@ -578,6 +579,7 @@
     "github.com/sirupsen/logrus",
     "k8s.io/api/batch/v1",
     "k8s.io/api/core/v1",
+    "k8s.io/api/extensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
@@ -592,6 +594,7 @@
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",
+    "k8s.io/client-go/dynamic",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/testing",

--- a/controller/cmd/resource-manager/app/options.go
+++ b/controller/cmd/resource-manager/app/options.go
@@ -1,0 +1,19 @@
+package app
+
+import "flag"
+
+type AppOption struct {
+	Action     string
+	Kubeconfig string
+	InputFile  string
+	OutputFile string
+	Timeout    string
+}
+
+func (opt *AppOption) AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&opt.Action, "action", "", "Action to take against the k8s resources.")
+	fs.StringVar(&opt.Kubeconfig, "kubeconfig", "", "Kubeconfig file (out of cluster only).")
+	fs.StringVar(&opt.InputFile, "input-file", "", "Path to the input file.")
+	fs.StringVar(&opt.OutputFile, "output-file", "", "Path to the output file.")
+	fs.StringVar(&opt.Timeout, "timeout", "15m", "Timeout for auto-watch.")
+}

--- a/controller/cmd/resource-manager/app/resource_manager.go
+++ b/controller/cmd/resource-manager/app/resource_manager.go
@@ -1,0 +1,164 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/rest"
+
+	"github.com/kubeflow/kubebench/controller/pkg/resource/client"
+	"github.com/kubeflow/kubebench/controller/pkg/resource/common"
+)
+
+// ResourceManager applies high level actions to resources
+type ResourceManager struct {
+	clusterConfig *rest.Config
+	inputReader   io.Reader
+	outputWriter  io.Writer
+}
+
+// NewResourceManager creates a new ResourceManager for the given config
+func NewResourceManager(config *rest.Config, reader io.Reader, writer io.Writer) *ResourceManager {
+	resourceManager := ResourceManager{
+		clusterConfig: config,
+		inputReader:   reader,
+		outputWriter:  writer,
+	}
+	return &resourceManager
+}
+
+// Run executes ResourceManager with given options
+func (m *ResourceManager) Run(opt *AppOption) error {
+	resourceClient, err := client.NewResourceClient(m.clusterConfig)
+	if err != nil {
+		log.Errorf("Failed to create resource client: %s", err)
+		return err
+	}
+	switch opt.Action {
+	case "create":
+		resourceObjects, err := getResourceObjects(m.inputReader)
+		if err != nil {
+			log.Errorf("Failed to get resource objects: %s", err)
+			return err
+		}
+		results, err := resourceClient.Create(resourceObjects)
+		if err != nil {
+			log.Errorf("Failed to run resource client: %s", err)
+			return err
+		}
+		if err := writeCreateResults(m.outputWriter, results); err != nil {
+			log.Errorf("Failed to write create results: %s", err)
+			return err
+		}
+	case "auto-watch":
+		resourceRefs, err := getResourceRefs(m.inputReader)
+		if err != nil {
+			log.Errorf("Failed to get resource-refs: %s", err)
+			return err
+		}
+		timeout, err := time.ParseDuration(opt.Timeout)
+		if err != nil {
+			log.Errorf("Failed to parse timeout value: %s", err)
+		}
+		results, err := resourceClient.AutoWatchByRef(resourceRefs, timeout)
+		if err != nil {
+			log.Errorf("Failed to run resource client: %s", err)
+			return err
+		}
+		if err := writeAutoWatchResults(m.outputWriter, results); err != nil {
+			log.Errorf("Failed to write auto-watch results: %s", err)
+			return err
+		}
+	default:
+		err := fmt.Errorf("Unknown action: %s", opt.Action)
+		log.Errorf("s", err)
+		return err
+	}
+	return nil
+}
+
+func getResourceObjects(reader io.Reader) ([]*unstructured.Unstructured, error) {
+	yamlReader := yaml.NewYAMLReader(bufio.NewReader(reader))
+	var resources []*unstructured.Unstructured
+
+	for {
+		data, err := yamlReader.Read()
+		if err != nil && err != io.EOF {
+			return nil, err
+		} else if err == io.EOF {
+			break
+		}
+
+		data, err = yaml.ToJSON(data)
+		if err != nil {
+			return nil, err
+		}
+
+		obj := unstructured.Unstructured{}
+		if err := json.Unmarshal(data, &obj); err != nil {
+			log.Errorf("Failed to parse manifest to k8s object: %s", err)
+			return nil, err
+		}
+		resources = append(resources, &obj)
+	}
+
+	return resources, nil
+}
+
+func getResourceRefs(reader io.Reader) ([]*common.ResourceRef, error) {
+	jsonDecoder := json.NewDecoder(reader)
+	var resourceRefs []*common.ResourceRef
+
+	for {
+		var ref common.ResourceRef
+		if err := jsonDecoder.Decode(&ref); err == io.EOF {
+			break
+		} else if err != nil {
+			log.Errorf("Failed to parse resource-ref file: %s", err)
+			return nil, err
+		}
+		resourceRefs = append(resourceRefs, &ref)
+	}
+
+	return resourceRefs, nil
+}
+
+func writeCreateResults(writer io.Writer, results []*common.ResourceRef) error {
+	jsonEncoder := json.NewEncoder(writer)
+	for _, ref := range results {
+		if err := jsonEncoder.Encode(ref); err != nil {
+			log.Errorf("Failed to write resource-ref file: %s", err)
+			return err
+		}
+	}
+	return nil
+}
+
+func writeAutoWatchResults(writer io.Writer, results []*client.WatchResult) error {
+	jsonEncoder := json.NewEncoder(writer)
+	for _, ref := range results {
+		if err := jsonEncoder.Encode(ref); err != nil {
+			log.Errorf("Failed to write watch-result file: %s", err)
+			return err
+		}
+	}
+	return nil
+}

--- a/controller/cmd/resource-manager/main.go
+++ b/controller/cmd/resource-manager/main.go
@@ -1,0 +1,89 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/kubeflow/kubebench/controller/cmd/resource-manager/app"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func run(opt *app.AppOption) error {
+
+	// create input reader
+	inputFile := opt.InputFile
+	inputReader, err := os.Open(inputFile)
+	if err != nil {
+		log.Errorf("Failed to open input file: %s", inputFile)
+		return err
+	}
+	defer inputReader.Close()
+
+	// create output writer
+	outputFile := opt.OutputFile
+	var outputWriter io.Writer
+	if outputFile == "" {
+		outputWriter = ioutil.Discard
+	} else {
+		fileWriter, err := os.Create(outputFile)
+		if err != nil {
+			log.Errorf("Failed to create output file: %s", outputFile)
+			return err
+		}
+		defer fileWriter.Close()
+		outputWriter = fileWriter
+	}
+
+	// get k8s client config
+	var config *rest.Config
+	if opt.Kubeconfig != "" {
+		config, err = clientcmd.BuildConfigFromFlags("", opt.Kubeconfig)
+		if err != nil {
+			log.Errorf("Failed to get config: %s", err)
+			return err
+		}
+	} else {
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			log.Errorf("Failed to get config: %s", err)
+			return err
+		}
+	}
+
+	// run resource manager
+	resourceManager := app.NewResourceManager(config, inputReader, outputWriter)
+	err = resourceManager.Run(opt)
+	if err != nil {
+		log.Errorf("Failed to run resource manager: %s", err)
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	opt := app.AppOption{}
+	opt.AddFlags(flag.CommandLine)
+	flag.Parse()
+
+	if err := run(&opt); err != nil {
+		log.Errorf("%s", err)
+		os.Exit(1)
+	}
+}

--- a/controller/pkg/resource/client/resource_client.go
+++ b/controller/pkg/resource/client/resource_client.go
@@ -1,0 +1,211 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"github.com/kubeflow/kubebench/controller/pkg/resource/common"
+	"github.com/kubeflow/kubebench/controller/pkg/resource/condition"
+)
+
+// ResourceClient interacts with the cluster and performs resource operations
+type ResourceClient struct {
+	discoveryClient *discovery.DiscoveryClient
+	dynamicClient   dynamic.Interface
+}
+
+// NewResourceClient creates a new ResourceClient
+func NewResourceClient(config *rest.Config) (*ResourceClient, error) {
+	discc, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		log.Errorf("Failed to create discovery client: %s", err)
+		return nil, err
+	}
+	dynac, err := dynamic.NewForConfig(config)
+	if err != nil {
+		log.Errorf("Failed to create dynamic client: %s", err)
+		return nil, err
+	}
+	return &ResourceClient{discoveryClient: discc, dynamicClient: dynac}, nil
+}
+
+// Create creates a list of resources to k8s cluster
+func (rc *ResourceClient) Create(resources []*unstructured.Unstructured) ([]*common.ResourceRef, error) {
+	var results []*common.ResourceRef
+	for _, r := range resources {
+		ref := common.NewResourceRefFromUnstructured(r)
+		kvgn := ref.SprintKindVersionGroupName()
+		ns := ref.Namespace
+		log.Infof("Creating resource: %s in namespace: %s", kvgn, ns)
+		apiRes, err := rc.getAPIResource(ref)
+		if err != nil {
+			return results, err
+		}
+		gvr := schema.GroupVersionResource{
+			Group:    ref.Group,
+			Version:  ref.Version,
+			Resource: apiRes.Name,
+		}
+		var resIf dynamic.ResourceInterface
+		if apiRes.Namespaced {
+			resIf = rc.dynamicClient.Resource(gvr).Namespace(ns)
+		} else {
+			resIf = rc.dynamicClient.Resource(gvr)
+		}
+		res, err := resIf.Create(r, metav1.CreateOptions{})
+		if err != nil {
+			log.Errorf("Failed to create resource %s: %s", kvgn, err)
+			return results, err
+		}
+		results = append(results, common.NewResourceRefFromUnstructured(res))
+	}
+	return results, nil
+}
+
+// AutoWatchByRef automatically watches a list of resources identified by ResourceRef.
+// Only supported types of resources are watched, others are ignored.
+func (rc *ResourceClient) AutoWatchByRef(refs []*common.ResourceRef, timeout time.Duration) ([]*WatchResult, error) {
+	var resultList []*WatchResult
+	var watchList []watchItem
+
+	for _, ref := range refs {
+		resCond := condition.NewResourceCondition(ref)
+		if resCond != nil {
+			apiRes, err := rc.getAPIResource(ref)
+			if err != nil {
+				return nil, err
+			}
+			item := watchItem{resourceRef: ref, apiResource: apiRes, resourceCond: resCond}
+			watchList = append(watchList, item)
+		}
+	}
+
+	resultChan := make(chan *WatchResult, len(watchList))
+	for _, wi := range watchList {
+		go func(resultChan chan<- *WatchResult) {
+			backoff := condition.Backoff{
+				Duration: time.Second * 5,
+				Factor:   2.0,
+				Jitter:   0.2,
+				Cap:      time.Minute * 10,
+			}
+			var resCondStatus condition.ResourceConditionStatus
+			err := condition.ExponentialBackoff(backoff, timeout, func() (bool, error) {
+				resObj, err := rc.getOneByRef(wi.resourceRef, wi.apiResource)
+				if err != nil {
+					return true, err
+				}
+				resCondStatus, err = wi.resourceCond.CheckCondition(resObj)
+				if err != nil {
+					return true, err
+				}
+				if resCondStatus == condition.ResourceConditionSuccess ||
+					resCondStatus == condition.ResourceConditionFailure {
+					return true, nil
+				}
+				return false, nil
+			})
+			if err != nil {
+				if err == condition.ErrWaitTimeout {
+					resCondStatus = condition.ResourceConditionTimeout
+					log.Errorf("Waiting for resource %s resulted in timeout",
+						wi.resourceRef.SprintKindVersionGroupName())
+				} else {
+					log.Errorf("Waiting for resource %s resulted in error: %s",
+						wi.resourceRef.SprintKindVersionGroupName(), err)
+				}
+			}
+			resultChan <- &WatchResult{ResourceRef: wi.resourceRef, Status: resCondStatus, Error: err}
+		}(resultChan)
+	}
+
+	for i := 0; i < len(watchList); i++ {
+		result := <-resultChan
+		resultList = append(resultList, result)
+	}
+
+	return resultList, nil
+}
+
+func (rc *ResourceClient) getAPIResource(r *common.ResourceRef) (*metav1.APIResource, error) {
+	apiResourceLists, err := rc.discoveryClient.ServerResources()
+	if err != nil {
+		return nil, err
+	}
+	var result *metav1.APIResource
+	// find the resource name from "kind"
+	for _, resList := range apiResourceLists {
+		groupVersion := resList.GroupVersion
+		if groupVersion != r.SprintGroupVersion() {
+			continue
+		}
+		for _, res := range resList.APIResources {
+			// find the resource that matches "kind", and is not a subresource
+			if res.Kind == r.Kind && !strings.Contains(res.Name, "/") {
+				result = &res
+				break
+			}
+		}
+	}
+	if result == nil {
+		err = fmt.Errorf("Cannot find resource for %s", r.SprintKindVersionGroup())
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// getOneByRef gets single resource's info from k8s cluster
+func (rc *ResourceClient) getOneByRef(ref *common.ResourceRef, apiRes *metav1.APIResource) (*unstructured.Unstructured, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    ref.Group,
+		Version:  ref.Version,
+		Resource: apiRes.Name,
+	}
+	var resIf dynamic.ResourceInterface
+	if apiRes.Namespaced {
+		resIf = rc.dynamicClient.Resource(gvr).Namespace(ref.Namespace)
+	} else {
+		resIf = rc.dynamicClient.Resource(gvr)
+	}
+	res, err := resIf.Get(ref.Name, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("Failed to get resource %s: %s", ref.SprintKindVersionGroupName(), err)
+		return nil, err
+	}
+	return res, nil
+}
+
+type watchItem struct {
+	resourceRef  *common.ResourceRef
+	apiResource  *metav1.APIResource
+	resourceCond condition.ResourceConditionInterface
+}
+
+// WatchResult is the result of auto-watch
+type WatchResult struct {
+	ResourceRef *common.ResourceRef               `json:"resourceRef"`
+	Status      condition.ResourceConditionStatus `json:"status"`
+	Error       error                             `json:"-"`
+}

--- a/controller/pkg/resource/common/common.go
+++ b/controller/pkg/resource/common/common.go
@@ -1,0 +1,61 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ResourceRef provides information that identifies a resource in a cluster
+type ResourceRef struct {
+	Group     string `json:"group"`
+	Version   string `json:"version"`
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+// NewResourceRefFromUnstructured creates a new ResourceRef from an Unstructured object
+func NewResourceRefFromUnstructured(resource *unstructured.Unstructured) *ResourceRef {
+	ref := ResourceRef{
+		Group:     resource.GroupVersionKind().Group,
+		Kind:      resource.GroupVersionKind().Kind,
+		Version:   resource.GroupVersionKind().Version,
+		Name:      resource.GetName(),
+		Namespace: resource.GetNamespace(),
+	}
+	return &ref
+}
+
+// SprintKindVersionGroup returns a string of "kind.version.group"
+func (r *ResourceRef) SprintKindVersionGroup() string {
+	return fmt.Sprintf("%s.%s.%s", r.Kind, r.Version, r.Group)
+}
+
+// SprintKindVersionGroupName returns a string of "kind.version.group/name"
+func (r *ResourceRef) SprintKindVersionGroupName() string {
+	return fmt.Sprintf("%s.%s.%s/%s", r.Kind, r.Version, r.Group, r.Name)
+}
+
+// SprintGroupVersion returns a string of "group/version"
+func (r *ResourceRef) SprintGroupVersion() string {
+	var groupVersion string
+	if r.Group == "" {
+		groupVersion = r.Version
+	} else {
+		groupVersion = r.Group + "/" + r.Version
+	}
+	return groupVersion
+}

--- a/controller/pkg/resource/condition/condition.go
+++ b/controller/pkg/resource/condition/condition.go
@@ -1,0 +1,54 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package condition
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kubeflow/kubebench/controller/pkg/resource/common"
+)
+
+var supportedResourceConditions = map[string]ResourceConditionInterface{
+	"Job.v1.batch":                  NewJobV1Condition(),
+	"Deployment.v1beta1.extensions": NewDeploymentV1beta1Condition(),
+}
+
+// ResourceConditionStatus is the status of a resource condition check
+type ResourceConditionStatus string
+
+const (
+	// ResourceConditionSuccess indicates success condition met
+	ResourceConditionSuccess ResourceConditionStatus = "Success"
+	// ResourceConditionFailure indicates failure condition met
+	ResourceConditionFailure ResourceConditionStatus = "Failure"
+	// ResourceConditionTimeout indicates condition check timed out
+	ResourceConditionTimeout ResourceConditionStatus = "Timeout"
+	// ResourceConditionUnknown indicates condition check returned unknown status or error
+	ResourceConditionUnknown ResourceConditionStatus = "Unknown"
+)
+
+// ResourceConditionInterface is the interface of resource condition checkers
+type ResourceConditionInterface interface {
+	CheckCondition(resource *unstructured.Unstructured) (ResourceConditionStatus, error)
+}
+
+// NewResourceCondition creates a new resource condition checker
+// The type of the condition checker depends on the given resource
+func NewResourceCondition(ref *common.ResourceRef) ResourceConditionInterface {
+	kvg := ref.SprintKindVersionGroup()
+	rc, found := supportedResourceConditions[kvg]
+	if found == false {
+		rc = nil
+	}
+	return rc
+}

--- a/controller/pkg/resource/condition/deployment.go
+++ b/controller/pkg/resource/condition/deployment.go
@@ -1,0 +1,57 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package condition
+
+import (
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// DeploymentV1beta1Condition is a condition checker for deployments in extensions/v1beta1
+type DeploymentV1beta1Condition struct{}
+
+// NewDeploymentV1beta1Condition creates a new DeploymentV1beta1Condition
+func NewDeploymentV1beta1Condition() *DeploymentV1beta1Condition {
+	return &DeploymentV1beta1Condition{}
+}
+
+// CheckCondition checks the status of a given deployment.
+// The success condition is met when number of available replicas = number of required replicas.
+// The failure condition is met when there is any replica failure.
+func (c *DeploymentV1beta1Condition) CheckCondition(resource *unstructured.Unstructured) (ResourceConditionStatus, error) {
+	var deployment extensionsv1beta1.Deployment
+	resStr, err := json.Marshal(resource)
+	if err != nil {
+		return ResourceConditionUnknown, err
+	}
+	err = json.Unmarshal(resStr, &deployment)
+	if err != nil {
+		return ResourceConditionUnknown, err
+	}
+
+	var result ResourceConditionStatus
+	for _, cond := range deployment.Status.Conditions {
+		if cond.Type == extensionsv1beta1.DeploymentReplicaFailure && cond.Status == corev1.ConditionTrue {
+			result = ResourceConditionFailure
+			break
+		}
+	}
+	if deployment.Status.AvailableReplicas == deployment.Status.Replicas {
+		result = ResourceConditionSuccess
+	}
+
+	return result, nil
+}

--- a/controller/pkg/resource/condition/job.go
+++ b/controller/pkg/resource/condition/job.go
@@ -1,0 +1,57 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package condition
+
+import (
+	"encoding/json"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// JobV1Condition is a condition checker for jobs in batch/v1
+type JobV1Condition struct{}
+
+// NewJobV1Condition creates a new JobV1Condition
+func NewJobV1Condition() *JobV1Condition {
+	return &JobV1Condition{}
+}
+
+// CheckCondition checks the status of a given job.
+// The success condition is met when a "Complete" type condition is observed.
+// The failure condition is met when a "Failed" type condition is observed.
+func (c *JobV1Condition) CheckCondition(resource *unstructured.Unstructured) (ResourceConditionStatus, error) {
+	var job batchv1.Job
+	resStr, err := json.Marshal(resource)
+	if err != nil {
+		return ResourceConditionUnknown, err
+	}
+	err = json.Unmarshal(resStr, &job)
+	if err != nil {
+		return ResourceConditionUnknown, err
+	}
+
+	var result ResourceConditionStatus
+	for _, cond := range job.Status.Conditions {
+		if cond.Type == batchv1.JobFailed && cond.Status == corev1.ConditionTrue {
+			result = ResourceConditionFailure
+			break
+		} else if cond.Type == batchv1.JobComplete && cond.Status == corev1.ConditionTrue {
+			result = ResourceConditionSuccess
+			break
+		}
+	}
+
+	return result, nil
+}

--- a/controller/pkg/resource/condition/wait.go
+++ b/controller/pkg/resource/condition/wait.go
@@ -1,0 +1,97 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package condition
+
+import (
+	"errors"
+	"math/rand"
+	"time"
+)
+
+// ConditionFunc returns true if the condition is satisfied, or an error
+// if the loop should be aborted.
+type ConditionFunc func() (done bool, err error)
+
+// ErrWaitTimeout is returned when the condition exited without success.
+var ErrWaitTimeout = errors.New("timed out waiting for the condition")
+
+// Backoff holds parameters applied to a Backoff function.
+type Backoff struct {
+	// The initial duration.
+	Duration time.Duration
+	// Duration is multiplied by factor each iteration. Must be greater
+	// than or equal to zero.
+	Factor float64
+	// The amount of jitter applied each iteration. Jitter is applied after
+	// cap.
+	Jitter float64
+	// The number of steps before duration stops changing. If zero, initial
+	// duration is always used. Used for exponential backoff in combination
+	// with Factor.
+	Steps int
+	// The returned duration will never be greater than cap *before* jitter
+	// is applied. The actual maximum cap is `cap * (1.0 + jitter)`.
+	Cap time.Duration
+}
+
+// Step returns the next interval in the exponential backoff. This method
+// will mutate the provided backoff.
+func (b *Backoff) Step() time.Duration {
+	if b.Steps < 1 {
+		return b.Duration
+	}
+	b.Steps--
+
+	duration := b.Duration
+
+	// calculate the next step
+	if b.Factor != 0 {
+		b.Duration = time.Duration(float64(b.Duration) * b.Factor)
+		if b.Cap > 0 && b.Duration > b.Cap {
+			b.Duration = b.Cap
+			b.Steps = 0
+		}
+	}
+	if b.Jitter > 0 {
+		duration = Jitter(duration, b.Jitter)
+	}
+
+	return duration
+}
+
+// Jitter returns a time.Duration between duration and duration + maxFactor *
+// duration.
+func Jitter(duration time.Duration, maxFactor float64) time.Duration {
+	if maxFactor <= 0.0 {
+		maxFactor = 1.0
+	}
+	wait := duration + time.Duration(rand.Float64()*maxFactor*float64(duration))
+	return wait
+}
+
+// ExponentialBackoff repeats a condition check with exponential backoff.
+func ExponentialBackoff(backoff Backoff, timeout time.Duration, condition ConditionFunc) error {
+	totalDuration := 0.0
+	for {
+		if ok, err := condition(); err != nil || ok {
+			return err
+		}
+		// if timeout <= 0 then no timeout is applied
+		if timeout > 0 && float64(totalDuration) >= float64(timeout) {
+			break
+		}
+		time.Sleep(backoff.Step())
+		totalDuration += float64(backoff.Duration)
+	}
+	return ErrWaitTimeout
+}

--- a/vendor/k8s.io/client-go/dynamic/interface.go
+++ b/vendor/k8s.io/client-go/dynamic/interface.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type Interface interface {
+	Resource(resource schema.GroupVersionResource) NamespaceableResourceInterface
+}
+
+type ResourceInterface interface {
+	Create(obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error)
+	Update(obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error)
+	UpdateStatus(obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error)
+	Delete(name string, options *metav1.DeleteOptions, subresources ...string) error
+	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
+	Get(name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error)
+	List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Patch(name string, pt types.PatchType, data []byte, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error)
+}
+
+type NamespaceableResourceInterface interface {
+	Namespace(string) ResourceInterface
+	ResourceInterface
+}
+
+// APIPathResolverFunc knows how to convert a groupVersion to its API path. The Kind field is optional.
+// TODO find a better place to move this for existing callers
+type APIPathResolverFunc func(kind schema.GroupVersionKind) string
+
+// LegacyAPIPathResolverFunc can resolve paths properly with the legacy API.
+// TODO find a better place to move this for existing callers
+func LegacyAPIPathResolverFunc(kind schema.GroupVersionKind) string {
+	if len(kind.Group) == 0 {
+		return "/api"
+	}
+	return "/apis"
+}

--- a/vendor/k8s.io/client-go/dynamic/scheme.go
+++ b/vendor/k8s.io/client-go/dynamic/scheme.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
+)
+
+var watchScheme = runtime.NewScheme()
+var basicScheme = runtime.NewScheme()
+var deleteScheme = runtime.NewScheme()
+var parameterScheme = runtime.NewScheme()
+var deleteOptionsCodec = serializer.NewCodecFactory(deleteScheme)
+var dynamicParameterCodec = runtime.NewParameterCodec(parameterScheme)
+
+var versionV1 = schema.GroupVersion{Version: "v1"}
+
+func init() {
+	metav1.AddToGroupVersion(watchScheme, versionV1)
+	metav1.AddToGroupVersion(basicScheme, versionV1)
+	metav1.AddToGroupVersion(parameterScheme, versionV1)
+	metav1.AddToGroupVersion(deleteScheme, versionV1)
+}
+
+var watchJsonSerializerInfo = runtime.SerializerInfo{
+	MediaType:        "application/json",
+	EncodesAsText:    true,
+	Serializer:       json.NewSerializer(json.DefaultMetaFactory, watchScheme, watchScheme, false),
+	PrettySerializer: json.NewSerializer(json.DefaultMetaFactory, watchScheme, watchScheme, true),
+	StreamSerializer: &runtime.StreamSerializerInfo{
+		EncodesAsText: true,
+		Serializer:    json.NewSerializer(json.DefaultMetaFactory, watchScheme, watchScheme, false),
+		Framer:        json.Framer,
+	},
+}
+
+// watchNegotiatedSerializer is used to read the wrapper of the watch stream
+type watchNegotiatedSerializer struct{}
+
+var watchNegotiatedSerializerInstance = watchNegotiatedSerializer{}
+
+func (s watchNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{watchJsonSerializerInfo}
+}
+
+func (s watchNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return versioning.NewDefaultingCodecForScheme(watchScheme, encoder, nil, gv, nil)
+}
+
+func (s watchNegotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return versioning.NewDefaultingCodecForScheme(watchScheme, nil, decoder, nil, gv)
+}
+
+// basicNegotiatedSerializer is used to handle discovery and error handling serialization
+type basicNegotiatedSerializer struct{}
+
+func (s basicNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{
+		{
+			MediaType:        "application/json",
+			EncodesAsText:    true,
+			Serializer:       json.NewSerializer(json.DefaultMetaFactory, basicScheme, basicScheme, false),
+			PrettySerializer: json.NewSerializer(json.DefaultMetaFactory, basicScheme, basicScheme, true),
+			StreamSerializer: &runtime.StreamSerializerInfo{
+				EncodesAsText: true,
+				Serializer:    json.NewSerializer(json.DefaultMetaFactory, basicScheme, basicScheme, false),
+				Framer:        json.Framer,
+			},
+		},
+	}
+}
+
+func (s basicNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return versioning.NewDefaultingCodecForScheme(watchScheme, encoder, nil, gv, nil)
+}
+
+func (s basicNegotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return versioning.NewDefaultingCodecForScheme(watchScheme, nil, decoder, nil, gv)
+}

--- a/vendor/k8s.io/client-go/dynamic/simple.go
+++ b/vendor/k8s.io/client-go/dynamic/simple.go
@@ -1,0 +1,326 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"io"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+)
+
+type dynamicClient struct {
+	client *rest.RESTClient
+}
+
+var _ Interface = &dynamicClient{}
+
+// NewForConfigOrDie creates a new Interface for the given config and
+// panics if there is an error in the config.
+func NewForConfigOrDie(c *rest.Config) Interface {
+	ret, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+func NewForConfig(inConfig *rest.Config) (Interface, error) {
+	config := rest.CopyConfig(inConfig)
+	// for serializing the options
+	config.GroupVersion = &schema.GroupVersion{}
+	config.APIPath = "/if-you-see-this-search-for-the-break"
+	config.AcceptContentTypes = "application/json"
+	config.ContentType = "application/json"
+	config.NegotiatedSerializer = basicNegotiatedSerializer{} // this gets used for discovery and error handling types
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	restClient, err := rest.RESTClientFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dynamicClient{client: restClient}, nil
+}
+
+type dynamicResourceClient struct {
+	client    *dynamicClient
+	namespace string
+	resource  schema.GroupVersionResource
+}
+
+func (c *dynamicClient) Resource(resource schema.GroupVersionResource) NamespaceableResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource}
+}
+
+func (c *dynamicResourceClient) Namespace(ns string) ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+func (c *dynamicResourceClient) Create(obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+	name := ""
+	if len(subresources) > 0 {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name = accessor.GetName()
+	}
+
+	result := c.client.client.
+		Post().
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(outBytes).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) Update(obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.
+		Put().
+		AbsPath(append(c.makeURLSegments(accessor.GetName()), subresources...)...).
+		Body(outBytes).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.
+		Put().
+		AbsPath(append(c.makeURLSegments(accessor.GetName()), "status")...).
+		Body(outBytes).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) Delete(name string, opts *metav1.DeleteOptions, subresources ...string) error {
+	if opts == nil {
+		opts = &metav1.DeleteOptions{}
+	}
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), opts)
+	if err != nil {
+		return err
+	}
+
+	result := c.client.client.
+		Delete().
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(deleteOptionsByte).
+		Do()
+	return result.Error()
+}
+
+func (c *dynamicResourceClient) DeleteCollection(opts *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	if opts == nil {
+		opts = &metav1.DeleteOptions{}
+	}
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), opts)
+	if err != nil {
+		return err
+	}
+
+	result := c.client.client.
+		Delete().
+		AbsPath(c.makeURLSegments("")...).
+		Body(deleteOptionsByte).
+		SpecificallyVersionedParams(&listOptions, dynamicParameterCodec, versionV1).
+		Do()
+	return result.Error()
+}
+
+func (c *dynamicResourceClient) Get(name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	result := c.client.client.Get().AbsPath(append(c.makeURLSegments(name), subresources...)...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	result := c.client.client.Get().AbsPath(c.makeURLSegments("")...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	if list, ok := uncastObj.(*unstructured.UnstructuredList); ok {
+		return list, nil
+	}
+
+	list, err := uncastObj.(*unstructured.Unstructured).ToList()
+	if err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
+func (c *dynamicResourceClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	internalGV := schema.GroupVersions{
+		{Group: c.resource.Group, Version: runtime.APIVersionInternal},
+		// always include the legacy group as a decoding target to handle non-error `Status` return types
+		{Group: "", Version: runtime.APIVersionInternal},
+	}
+	s := &rest.Serializers{
+		Encoder: watchNegotiatedSerializerInstance.EncoderForVersion(watchJsonSerializerInfo.Serializer, c.resource.GroupVersion()),
+		Decoder: watchNegotiatedSerializerInstance.DecoderToVersion(watchJsonSerializerInfo.Serializer, internalGV),
+
+		RenegotiatedDecoder: func(contentType string, params map[string]string) (runtime.Decoder, error) {
+			return watchNegotiatedSerializerInstance.DecoderToVersion(watchJsonSerializerInfo.Serializer, internalGV), nil
+		},
+		StreamingSerializer: watchJsonSerializerInfo.StreamSerializer.Serializer,
+		Framer:              watchJsonSerializerInfo.StreamSerializer.Framer,
+	}
+
+	wrappedDecoderFn := func(body io.ReadCloser) streaming.Decoder {
+		framer := s.Framer.NewFrameReader(body)
+		return streaming.NewDecoder(framer, s.StreamingSerializer)
+	}
+
+	opts.Watch = true
+	return c.client.client.Get().AbsPath(c.makeURLSegments("")...).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		WatchWithSpecificDecoders(wrappedDecoderFn, unstructured.UnstructuredJSONScheme)
+}
+
+func (c *dynamicResourceClient) Patch(name string, pt types.PatchType, data []byte, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	result := c.client.client.
+		Patch(pt).
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(data).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) makeURLSegments(name string) []string {
+	url := []string{}
+	if len(c.resource.Group) == 0 {
+		url = append(url, "api")
+	} else {
+		url = append(url, "apis", c.resource.Group)
+	}
+	url = append(url, c.resource.Version)
+
+	if len(c.namespace) > 0 {
+		url = append(url, "namespaces", c.namespace)
+	}
+	url = append(url, c.resource.Resource)
+
+	if len(name) > 0 {
+		url = append(url, name)
+	}
+
+	return url
+}


### PR DESCRIPTION
The resource-manager applies high level actions to user defined resources
from a benchmark workflow. This patch adds initial resource-manager with
the following action supports:

- create: creates a list of resources defined in a multi-doc manifest file
- auto-watch: automatically watch for success/failure conditions in
  supported resources. Deployments and Jobs are currently supported
  resources. Other kinds of resouces will be ignored and not watched.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubebench/172)
<!-- Reviewable:end -->
