### PR TITLE
Add input-data and num-copies options to resource-manager

### DIFF
--- a/controller/cmd/resource-manager/app/options.go
+++ b/controller/cmd/resource-manager/app/options.go
@@ -5,15 +5,19 @@ import "flag"
 type AppOption struct {
 	Action     string
 	Kubeconfig string
+	InputData  string
 	InputFile  string
 	OutputFile string
+	NumCopies  int
 	Timeout    string
 }
 
 func (opt *AppOption) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&opt.Action, "action", "", "Action to take against the k8s resources.")
 	fs.StringVar(&opt.Kubeconfig, "kubeconfig", "", "Kubeconfig file (out of cluster only).")
-	fs.StringVar(&opt.InputFile, "input-file", "", "Path to the input file.")
+	fs.StringVar(&opt.InputData, "input-data", "", "Input data.")
+	fs.StringVar(&opt.InputFile, "input-file", "", "Path to the file containing input data.")
 	fs.StringVar(&opt.OutputFile, "output-file", "", "Path to the output file.")
+	fs.IntVar(&opt.NumCopies, "num-copies", 1, "Number of copies to create.")
 	fs.StringVar(&opt.Timeout, "timeout", "15m", "Timeout for auto-watch.")
 }

--- a/controller/cmd/resource-manager/app/resource_manager.go
+++ b/controller/cmd/resource-manager/app/resource_manager.go
@@ -59,7 +59,7 @@ func (m *ResourceManager) Run(opt *AppOption) error {
 			log.Errorf("Failed to get resource objects: %s", err)
 			return err
 		}
-		results, err := resourceClient.Create(resourceObjects)
+		results, err := resourceClient.Create(resourceObjects, opt.NumCopies)
 		if err != nil {
 			log.Errorf("Failed to run resource client: %s", err)
 			return err

--- a/controller/cmd/resource-manager/main.go
+++ b/controller/cmd/resource-manager/main.go
@@ -13,6 +13,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"io"
 	"io/ioutil"
@@ -27,13 +28,18 @@ import (
 func run(opt *app.AppOption) error {
 
 	// create input reader
+	var inputData []byte
+	var err error
+	inputData = []byte(opt.InputData)
 	inputFile := opt.InputFile
-	inputReader, err := os.Open(inputFile)
-	if err != nil {
-		log.Errorf("Failed to open input file: %s", inputFile)
-		return err
+	if inputFile != "" {
+		inputData, err = ioutil.ReadFile(inputFile)
+		if err != nil {
+			log.Errorf("Failed to read input file: %s", inputFile)
+			return err
+		}
 	}
-	defer inputReader.Close()
+	inputReader := bytes.NewReader(inputData)
 
 	// create output writer
 	outputFile := opt.OutputFile


### PR DESCRIPTION
This allows the resource-manager to be able to
- get input data from command line directly instead of file
- launch multiple copies of given resources

Partially addresses #173 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubebench/183)
<!-- Reviewable:end -->
