### PR TITLE
Fix kubebench-config passing in operator

### DIFF
--- a/controller/pkg/controller/kubebenchjob/v1alpha2/controller.go
+++ b/controller/pkg/controller/kubebenchjob/v1alpha2/controller.go
@@ -97,6 +97,7 @@ func NewKubebenchJobController(
 			workqueue.DefaultControllerRateLimiter(), "kubebenchjob"),
 		recorder: record.NewBroadcaster().NewRecorder(
 			scheme.Scheme, corev1.EventSource{Component: "kubebenchjob-controller"}),
+		config: config,
 	}
 
 	kbJobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION
This fixes the missing config problem in kubebench operator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubebench/207)
<!-- Reviewable:end -->
