### PR TITLE
Fix auto-generated environment variables

### DIFF
--- a/controller/pkg/workflow/workflowinfo.go
+++ b/controller/pkg/workflow/workflowinfo.go
@@ -61,9 +61,14 @@ func newWorkflowInfo(kbjob *kbjobv1alpha2.KubebenchJob) *workflowInfo {
 
 	envVars := []corev1.EnvVar{
 		{
-			Name:  constants.WorkflowRootEnvName,
-			Value: constants.WorkflowRootPath,
+			Name:  constants.ExpIDEnvName,
+			Value: experimentID,
 		},
+		// NOTE: WorkflowRootPath is not available to use. Mount point at WorkflowExpRootPath.
+		// {
+		// 	Name:  constants.WorkflowRootEnvName,
+		// 	Value: constants.WorkflowRootPath,
+		// },
 		{
 			Name:  constants.WorkflowExpRootEnvName,
 			Value: constants.WorkflowExpRootPath,


### PR DESCRIPTION
- add EXPERIMENT_ID which is necessary for workflow agent to work correctly
- remove WORKFLOW_ROOT_PATH which is not supposed to be used by user at the moment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubebench/209)
<!-- Reviewable:end -->
