### PR TITLE
Kubebench: Move manifests development upstream

### DIFF
--- a/manifests/base/cluster-role-binding.yaml
+++ b/manifests/base/cluster-role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubebench-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubebench-operator
+subjects:
+- kind: ServiceAccount
+  name: kubebench-operator

--- a/manifests/base/cluster-role.yaml
+++ b/manifests/base/cluster-role.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kubebench-operator
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - kubebenchjobs
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - pods/exec
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs
+  - pytorchjobs
+  - mpijobs
+  verbs:
+  - '*'
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - '*'

--- a/manifests/base/config-map.yaml
+++ b/manifests/base/config-map.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubebench-config
+data:
+  kubebenchconfig.yaml: |
+    defaultWorkflowAgent:
+      container:
+        name: kubebench-workflow-agent
+        image: gcr.io/kubeflow-images-public/kubebench/workflow-agent:bc682c1
+    defaultManagedVolumes:
+      experimentVolume:
+        name: kubebench-experiment-volume
+        emptyDir: {}
+      workflowVolume:
+        name: kubebench-workflow-volume
+        emptyDir: {}

--- a/manifests/base/crd.yaml
+++ b/manifests/base/crd.yaml
@@ -1,0 +1,11 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubebenchjobs.kubeflow.org
+spec:
+  group: kubeflow.org
+  names:
+    kind: KubebenchJob
+    plural: kubebenchjobs
+  scope: Namespaced
+  version: v1alpha2

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubebench-operator
+spec:
+  selector:
+    matchLabels:
+      app: kubebench-operator
+  template:
+    metadata:
+      labels:
+        app: kubebench-operator
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      volumes:
+      - name: kubebench-config
+        configMap:
+          name: kubebench-config
+      containers:
+      - image: gcr.io/kubeflow-images-public/kubebench/kubebench-operator-v1alpha2
+        name: kubebench-operator
+        command:
+        - /app/kubebench-operator-v1alpha2
+        args:
+        - --config=/config/kubebenchconfig.yaml
+        volumeMounts:
+        - mountPath: /config
+          name: kubebench-config
+      serviceAccountName: kubebench-operator

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- service-account.yaml
+- cluster-role-binding.yaml
+- cluster-role.yaml
+- crd.yaml
+- config-map.yaml
+- deployment.yaml
+namespace: kubeflow
+commonLabels:
+  kustomize.component: kubebench
+configMapGenerator:
+- name: parameters
+  envs:
+  - params.env
+images:
+  # NOTE: the image for workflow agent should be configured in config-map.yaml
+  - name:  gcr.io/kubeflow-images-public/kubebench/kubebench-operator-v1alpha2
+    newName: gcr.io/kubeflow-images-public/kubebench/kubebench-operator-v1alpha2
+    newTag: bc682c1
+vars:
+- name: clusterDomain
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.clusterDomain
+configurations:
+- params.yaml

--- a/manifests/base/params.env
+++ b/manifests/base/params.env
@@ -1,0 +1,2 @@
+namespace=
+clusterDomain=cluster.local

--- a/manifests/base/params.yaml
+++ b/manifests/base/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: metadata/annotations/getambassador.io\/config
+  kind: Service

--- a/manifests/base/service-account.yaml
+++ b/manifests/base/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: kubebench-operator
+  name: kubebench-operator

--- a/manifests/overlays/application/application.yaml
+++ b/manifests/overlays/application/application.yaml
@@ -1,0 +1,31 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: kubebench
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubebench
+      app.kubernetes.io/instance: kubebench-v0.7.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: kubebench
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.7.0
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  descriptor:
+    type: kubebench
+    version: v1beta1
+    description: "Makes it easy to run benchmark jobs on Kubeflow with various system and model settings"
+    maintainers: []
+    owners: []
+    keywords:
+     - kubebench
+     - kubeflow
+    links:
+    - description: About
+      url: https://github.com/kubeflow/kubebench
+  addOwnerRef: true

--- a/manifests/overlays/application/kustomization.yaml
+++ b/manifests/overlays/application/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+bases:
+- ../../base
+commonLabels:
+  app.kubernetes.io/component: kubebench
+  app.kubernetes.io/name: kubebench
+kind: Kustomization
+resources:
+- application.yaml

--- a/manifests/overlays/istio/kustomization.yaml
+++ b/manifests/overlays/istio/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+resources:
+- virtual-service.yaml
+configurations:
+- params.yaml

--- a/manifests/overlays/istio/params.yaml
+++ b/manifests/overlays/istio/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: spec/http/route/destination/host
+  kind: VirtualService

--- a/manifests/overlays/istio/virtual-service.yaml
+++ b/manifests/overlays/istio/virtual-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: kubebench-dashboard
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /dashboard/
+    rewrite:
+      uri: /dashboard/
+    route:
+    - destination:
+        host: kubebench-dashboard.$(namespace).svc.$(clusterDomain)
+        port:
+          number: 80


### PR DESCRIPTION

### Issue Resolved

Resolves: https://github.com/kubeflow/kubebench/issues/216
Umbrella issue: https://github.com/kubeflow/manifests/issues/1740

### Description

As part of the work of wg-manifests for 1.3
(https://github.com/kubeflow/manifests/issues/1735), we are moving manifests
development in upstream repos. This gives the application developers full
ownership of their manifests, tracked in a single place.

This PR copies the manifests for application `Kubebench`
from path `apps/kubebench/upstream` of kubeflow/manifests to path
`manifests` of the upstream repo (https://github.com/kubeflow/kubebench).

cc @kubeflow/wg-training-leads